### PR TITLE
fix catalog pre validation script

### DIFF
--- a/tests/scripts/pre-validation-deploy-ocp-and-scc-wp-instances.sh
+++ b/tests/scripts/pre-validation-deploy-ocp-and-scc-wp-instances.sh
@@ -28,9 +28,9 @@ TF_VARS_FILE="terraform.tfvars"
 
   region_var_name="region"
   cluster_id_var_name="cluster_id"
-  cluster_id_value=$(terraform output -state=terraform.tfstate -raw workload_cluster_id)
+  cluster_id_value=$(terraform output -state=terraform.tfstate -raw cluster_id)
   cluster_resource_group_id_var_name="cluster_resource_group_id"
-  cluster_resource_group_id_value=$(terraform output -state=terraform.tfstate -raw cluster_resource_group_id)
+  cluster_resource_group_id_value=$(terraform output -state=terraform.tfstate -raw resource_group_id)
   access_key_var_name="access_key"
   access_key_value=$(terraform output -state=terraform.tfstate -raw access_key)
 


### PR DESCRIPTION
### Description

The outputs were changed in https://github.com/terraform-ibm-modules/terraform-ibm-scc-workload-protection-agent/pull/294 but I forgot to update this script used by catalog pipeline

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
